### PR TITLE
DictionarySettingsProviderPatcher - removed strong type binding

### DIFF
--- a/ModMenu/NewTypes/SettingsEntityPatches.cs
+++ b/ModMenu/NewTypes/SettingsEntityPatches.cs
@@ -52,11 +52,11 @@ namespace ModMenu.NewTypes
         {
           return typeof(DictionarySettingsProvider)
                 .GetMethod(nameof(DictionarySettingsProvider.GetValue))
-                .MakeGenericMethod(typeof(ModsMenuEntry));
+                .MakeGenericMethod(typeof(object));
         }
 
         [HarmonyPrefix]
-        public static bool DeserializeSettingEntry(string key, ref ModsMenuEntry __result)
+        public static bool DeserializeSettingEntry(string key, ref object __result)
         {
           if (key.Equals(SettingsEntityModMenuEntry.instance.Key))
           {


### PR DESCRIPTION
Core issue: 
`DictionarySettingsProvider.GetValue` patch is messing up with type bindings. This prevents you from retrieving string values from settings.

```csharp
    SettingsController.GeneralSettingsProvider.SetValue("test-setting", "test value");
    var value = SettingsController.GeneralSettingsProvider.GetValue("test-setting", "default");
```
`value` will always be null because the original method fails to match `obj is TSettingsValue` as type is already bound to `ModsMenuEntry` by this prefix.

```csharp
public TSettingsValue GetValue<TSettingsValue>(string key, TSettingsValue valueDefault)
{
    object obj;
    this.Dictionary.TryGetValue(key, out obj);
    if (obj is TSettingsValue)
    {
        return (TSettingsValue)((object)obj);
    }

    ...
}
```
Also, you will see errors in `GameLog.txt` like `[21.7737 - Settings]: Can't cast test value to Enum type ModMenu.Settings.ModsMenuEntry. Setting default.` caused by further original method logic when it fails to match types.


This does look like a general issue with harmony patching, as the prefix is targeted to apply only to `ModsMenuEntry` generic method body, but it still runs for `string` types as well.

This PR makes the prefix apply to all generic bodies, but we are only interested in a key match to set an empty `ModsMenuEntry` instance, so this preserves the original functionality

I did verify that this fix solves issues with retrieving string settings / keeps ModMenu functioning, but I would be glad if someone familiar with ModMenu could verify it as well 

<img width="2552" height="590" alt="Screenshot 2026-05-05 152710" src="https://github.com/user-attachments/assets/def5caf7-fb5d-4954-ad61-4efa5c071e7d" />

<img width="2528" height="427" alt="Screenshot 2026-05-05 153340" src="https://github.com/user-attachments/assets/3cb8ea0b-0cda-465d-9a79-b724da5d0348" />

<img width="2547" height="953" alt="Screenshot 2026-05-05 153351" src="https://github.com/user-attachments/assets/363270d0-1556-41ef-94dc-dcfcb215667e" />


without MP mod:
<img width="2528" height="376" alt="image" src="https://github.com/user-attachments/assets/e295d8d5-0da2-4f23-a374-02c40c6dffc2" />
